### PR TITLE
Clear Expect's accumulator after login to start from a clean slate

### DIFF
--- a/lib/Gerty/CLI/DirectAccess.pm
+++ b/lib/Gerty/CLI/DirectAccess.pm
@@ -180,6 +180,7 @@ sub connect
     }
     
     $Gerty::log->debug('Logged in at ' . $ipaddr);
+    $exp->clear_accum();
     $self->{'expect'} = $exp;
     return $exp;
 }


### PR DESCRIPTION
Some devices (my Pix 515e v6.35) give two consecutive prompts after login.
This breaks the normal Expect flow and causes unnecessary failure.
By clearing Expect's accumulator immediately after login we can help
ensure that subsequent Expect commands will be starting from a clean slate.
